### PR TITLE
Railtie to pull in Rake Tasks

### DIFF
--- a/lib/yaml_db.rb
+++ b/lib/yaml_db.rb
@@ -64,4 +64,11 @@ module YamlDb
     end
   end
 
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load File.expand_path('../../tasks/yaml_db_tasks.rake', 
+__FILE__)
+    end
+  end
+
 end


### PR DESCRIPTION
Hi Ludicast,

I'm new to both Rails and Github, so pardon me if this is the incorrect way to approach this.   I modified the yaml_db.rb file to include a Railtie that loads the Rake tasks.  This way, you don't have to do that first step int he README file and can begin using yaml_db as soon as you install the em. If that's in any way helpful to the project, feel free to use it.

Thanks,

Justin
