### PR TITLE
Fix boolean checks to support oracle

### DIFF
--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -115,10 +115,14 @@ module SerializationHelper
       records.each do |record|
         columns.each do |column|
           next if is_boolean(record[column])
-          record[column] = (record[column] == 't' or record[column] == '1')
+          record[column] = convert_boolean(record[column])
         end
       end
       records
+    end
+
+    def self.convert_boolean(value)
+      ['t', '1', true, 1].include?(value)
     end
 
     def self.boolean_columns(table)

--- a/spec/serialization_utils_spec.rb
+++ b/spec/serialization_utils_spec.rb
@@ -28,4 +28,24 @@ describe SerializationHelper::Utils, " convert records utility method" do
 		ActiveRecord::Base.connection.should_receive(:quote_table_name).with('values').and_return('`values`')
 		SerializationHelper::Utils.quote_table('values').should == '`values`'
 	end
+
+  it "should convert ruby booleans to true and false" do
+		SerializationHelper::Utils.convert_boolean(true).should == true
+		SerializationHelper::Utils.convert_boolean(false).should == false
+  end
+
+  it "should convert ruby string t and f to true and false" do
+		SerializationHelper::Utils.convert_boolean('t').should == true
+		SerializationHelper::Utils.convert_boolean('f').should == false
+  end
+
+  it "should convert ruby string 1 and 0 to true and false" do
+		SerializationHelper::Utils.convert_boolean('1').should == true
+		SerializationHelper::Utils.convert_boolean('0').should == false
+  end
+
+  it "should convert ruby integer 1 and 0 to true and false" do
+		SerializationHelper::Utils.convert_boolean(1).should == true
+		SerializationHelper::Utils.convert_boolean(0).should == false
+  end
 end


### PR DESCRIPTION
Hey guys,

I ran into a problem when dumping an Oracle DB into yml - booleans were always returned as false. This is because they are always stored as 1-bit integers (i.e. 1 or 0) in Oracle-land.

I've refactored convert_booleans to call convert_boolean to determine a given values boolean equivalent, added test cases for the code and allowing boolean true and integer 1 to be transformed to boolean true.

Hope there's enough for you to merge in!

Thanks for yaml_db, it's very helpful our team.

```
Rob
```
