### PR TITLE
use Rails.root instead RAILS_ROOT in rake task for Rails 3

### DIFF
--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -11,7 +11,7 @@ namespace :db do
         end
             
         def dump_dir(dir = "")
-          "#{RAILS_ROOT}/db#{dir}"
+          "#{Rails.root}/db#{dir}"
         end
 
 		desc "Dump contents of database to db/data.extension (defaults to yaml)"


### PR DESCRIPTION
I was getting this error running the rake db:data:load task: uninitialized constant Rails::DeprecatedConstant::Rails, reading the rails 3 changelog I get realized about this

Railties now deprecates:

RAILS_ROOT in favour of Rails.root,
RAILS_ENV in favour of Rails.env, and
RAILS_DEFAULT_LOGGER in favour of Rails.logger.
