### PR TITLE
Support for dumping only selected tables from database

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,19 @@ Further, there are tasks db:dump and db:load which do the entire database (the e
     rake db:data:dump_dir   ->   Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)
     rake db:data:load_dir   ->   Load contents of db/data_dir into database
 
+Also, it is possible to dump only selected tables of your database:
+
+    rake db:data:dump_dir filter_tables=^table[0-5]$|other_table
+    rake db:data:dump filter_tables=^table[0-5]$|other_table
+
+(Beware that the `filter_tables` paramater is evaluated as a regular expression
+(with `Regexp.new(filter_tables)`), so:
+
+    rake db:data:dump_dir filter_tables=mytable
+
+will dump `mytable`, but also `mytable_join_other_table`.
+
+
 In addition, we have plugins whereby you can export your database to/from various formats.  We only deal with yaml and csv right now, but you can easily write tools for your own formats (such as Excel or XML).  To use another format, just load setting the "class"  parameter to the class you are using.  This defaults to "YamlDb::Helper" which is a refactoring of the old yaml_db code.  We'll shorten this to use class nicknames in a little bit.
 
 ## Examples

--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -3,10 +3,11 @@ module SerializationHelper
   class Base
     attr_reader :extension
 
-    def initialize(helper)
+    def initialize(helper, filter_table_names = nil)
       @dumper = helper.dumper
       @loader = helper.loader
       @extension = helper.extension
+      @dumper.filter_table_names = filter_table_names if filter_table_names
     end
 
     def dump(filename)
@@ -137,6 +138,10 @@ module SerializationHelper
   end
 
   class Dump
+    class << self
+      attr_accessor :filter_table_names
+    end
+
     def self.before_table(io, table)
 
     end
@@ -154,7 +159,9 @@ module SerializationHelper
     end
 
     def self.tables
-      ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }
+      all_tables = ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }
+
+      filter_table_names ? all_tables.grep(Regexp.new(filter_table_names)) : all_tables
     end
 
     def self.dump_table(io, table)

--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -18,14 +18,16 @@ namespace :db do
 		task :dump => :environment do
             format_class = ENV['class'] || "YamlDb::Helper"
             helper = format_class.constantize
-			SerializationHelper::Base.new(helper).dump db_dump_data_file helper.extension
+            filter = ENV['filter_tables']
+            SerializationHelper::Base.new(helper,filter).dump db_dump_data_file helper.extension
 		end
 
 		desc "Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)"
 		task :dump_dir => :environment do
             format_class = ENV['class'] || "YamlDb::Helper"
             dir = ENV['dir'] || "#{Time.now.to_s.gsub(/ /, '_')}"
-            SerializationHelper::Base.new(format_class.constantize).dump_to_dir dump_dir("/#{dir}")
+            filter = ENV['filter_tables']
+            SerializationHelper::Base.new(format_class.constantize, filter).dump_to_dir dump_dir("/#{dir}")
 		end
 
 		desc "Load contents of db/data.extension (defaults to yaml) into database"

--- a/spec/serialization_helper_base_spec.rb
+++ b/spec/serialization_helper_base_spec.rb
@@ -33,6 +33,11 @@ describe SerializationHelper::Base do
          SerializationHelper::Base.new(@helper).dump_to_dir "dir_name"
       end   
 
+      it "should be able to be configured such as it will dump only selected tables" do
+        @dumper.should_receive(:"filter_table_names=").with("table_filter")
+        SerializationHelper::Base.new(@helper, "table_filter").dump_to_dir "dir_name"
+      end
+
     end
 
     context "for multi-file loads" do


### PR DESCRIPTION
Hi there!

I've implemented some code such that you can dump only selected tables from database:

```
rake db:data:dump filter_tables=^table[0-5]$|other_table
rake db:data:dump_dir filter_tables=^table[0-5]$|other_table
```

(I've updated the readme, and set some new specs, so i guess it's ready to be merged).

If you think this needs some other changes, feel free to contact me.

I've also updated Rails2 branch, I'll start a new pull request.

Thanks!!
