### PR TITLE
yaml_db only worked for me after converting the query object to a SQL string

### DIFF
--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -182,7 +182,7 @@ module SerializationHelper
 
       (0..pages).to_a.each do |page|
         query = Arel::Table.new(table).order(id).skip(records_per_page*page).take(records_per_page).project(Arel.sql('*'))
-        records = ActiveRecord::Base.connection.select_all(query)
+        records = ActiveRecord::Base.connection.select_all(query.to_sql)
         records = SerializationHelper::Utils.convert_booleans(records, boolean_columns)
         yield records
       end


### PR DESCRIPTION
Trying to export from sqlite3 I was getting this error:

TypeError: can't convert Arel::SelectManager into String: #Arel::SelectManager:0x000000039ee7d0

with this on the stack:

yaml_db-0.2.3/lib/serialization_helper.rb:185:in `block in each_table_page'

and this change fixed it for me.
