### PR TITLE
Allow choosing base; also added StdoutBase to allow dumping to STDOUT

### DIFF
--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -1,5 +1,13 @@
 module SerializationHelper
 
+  def self.get_base(other_base=nil)
+    if other_base
+      other_base.constantize
+    else
+      self::Base
+    end
+  end
+
   class Base
     attr_reader :extension
 
@@ -51,6 +59,14 @@ module SerializationHelper
     end
   end
   
+  class StdoutBase < Base
+    def dump(filename)
+      disable_logger
+      @dumper.dump(STDOUT)
+      reenable_logger
+    end
+  end
+
   class Load
     def self.load(io, truncate = true)
       ActiveRecord::Base.connection.transaction do

--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -17,8 +17,10 @@ namespace :db do
     desc "Dump contents of database to db/data.extension (defaults to yaml)"
     task :dump => :environment do
       format_class = ENV['class'] || "YamlDb::Helper"
+      output_base = ENV["output_base"]
       helper = format_class.constantize
-      SerializationHelper::Base.new(helper).dump db_dump_data_file helper.extension
+      base = SerializationHelper::get_base(output_base)
+      base.new(helper).dump db_dump_data_file helper.extension
     end
 
     desc "Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)"

--- a/spec/serialization_helper_base_spec.rb
+++ b/spec/serialization_helper_base_spec.rb
@@ -38,6 +38,16 @@ describe SerializationHelper::Base do
 
     end
 
+    context "selecting base to use" do
+      it "should use SerializationHelper::Base by default" do
+        SerializationHelper::get_base.should == SerializationHelper::Base
+      end
+
+      it "should be possible to use base specified as parameter" do
+        SerializationHelper::get_base("SerializationHelper::StdoutBase").should == SerializationHelper::StdoutBase
+      end
+    end
+
     context "for multi-file loads" do
 
       before do


### PR DESCRIPTION
I added the possibility of dumping to STDOUT. I also added a Rake task called **dump_to_stdout**, and two small tests.

Here's why I find this functionality helpful:

I use Heroku for developing, and sometimes I need to do a database dump. The thing is, exporting the database using taps almost never works, so I started looking for an alternative. By allowing the output to be dumped to STDOUT, I can run the following command:

``` bash
heroku run rake db:data:dump output_base=SerializationHelper::StdoutBase --app myapp > db/data.yml
```

And, this way, I can write the dump to my own computer. Please have a look, see if you find this helpful/worthy of integrating in your code :)

Best wishes,

George
