### PR TITLE
Compatible with Rails4

### DIFF
--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -4,8 +4,8 @@ module SerializationHelper
     attr_reader :extension
 
     def initialize(helper)
-      @dumper = helper.dumper
-      @loader = helper.loader
+      @dumper    = helper.dumper
+      @loader    = helper.loader
       @extension = helper.extension
     end
 
@@ -22,7 +22,7 @@ module SerializationHelper
         io = File.new "#{dirname}/#{table}.#{@extension}", "w"
         @dumper.before_table(io, table)
         @dumper.dump_table io, table
-        @dumper.after_table(io, table)         
+        @dumper.after_table(io, table)
       end
     end
 
@@ -38,7 +38,7 @@ module SerializationHelper
           next
         end
         @loader.load(File.new("#{dirname}/#{filename}", "r"), truncate)
-      end   
+      end
     end
 
     def disable_logger
@@ -50,7 +50,7 @@ module SerializationHelper
       ActiveRecord::Base.logger = @@old_logger
     end
   end
-  
+
   class Load
     def self.load(io, truncate = true)
       ActiveRecord::Base.connection.transaction do
@@ -92,9 +92,8 @@ module SerializationHelper
       if ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
         ActiveRecord::Base.connection.reset_pk_sequence!(table_name)
       end
-    end    
+    end
 
-      
   end
 
   module Utils

--- a/lib/yaml_db.rb
+++ b/lib/yaml_db.rb
@@ -44,8 +44,8 @@ module YamlDb
       column_names = table_column_names(table)
 
       each_table_page(table) do |records|
-        rows = SerializationHelper::Utils.unhash_records(records, column_names)
-        io.write(YamlDb::Utils.chunk_records(records))
+        rows = SerializationHelper::Utils.unhash_records(records.to_a, column_names)
+        io.write(YamlDb::Utils.chunk_records(rows))
       end
     end
 


### PR DESCRIPTION
Fixed issues with integration in rails4 application.
1. Still use ActiveRecord:: Result instead of Array:

```
categories:
  columns:
  - id
  - category
  - precedence
  - created_at
  - updated_at
  records: 
- !ruby/object:ActiveRecord::Result
  columns:
  - id
  - category
  - precedence
  - created_at
  - updated_at
  rows:
  - - '1'
    - Dentist
    - '1'
```
1. Incorrect type

```
rake aborted!
undefined method `[]=' for #<ActiveRecord::Result:0x007ff50153cc00>
.../yaml_db/lib/serialization_helper.rb:108:in `block in unhash_records'

```
