### PR TITLE
Do not exclude schema_migrations and schema_info tables from dump

### DIFF
--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -158,7 +158,7 @@ module SerializationHelper
     end
 
     def self.tables
-      ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }
+      ActiveRecord::Base.connection.tables
     end
 
     def self.dump_table(io, table)

--- a/spec/serialization_helper_dump_spec.rb
+++ b/spec/serialization_helper_dump_spec.rb
@@ -21,7 +21,7 @@ describe SerializationHelper::Dump do
 		SerializationHelper::Dump.table_column_names('mytable').should == [ 'a', 'b' ]
 	end
 
-	it "should return a list of tables without the rails schema table" do
+	it "should return a list of tables including the rails schema table" do
 		SerializationHelper::Dump.tables.should == ['mytable', 'schema_info', 'schema_migrations']
 	end
 

--- a/spec/serialization_helper_dump_spec.rb
+++ b/spec/serialization_helper_dump_spec.rb
@@ -22,7 +22,7 @@ describe SerializationHelper::Dump do
 	end
 
 	it "should return a list of tables without the rails schema table" do
-		SerializationHelper::Dump.tables.should == ['mytable']
+		SerializationHelper::Dump.tables.should == ['mytable', 'schema_info', 'schema_migrations']
 	end
 
 	it "should return the total number of records in a table" do


### PR DESCRIPTION
See eadz/yaml_db#1 for a reasoning.
