### PR TITLE
Rails4 support, PostgreSQL array and hstore fields support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/.DS_Store
+/.idea

--- a/README.markdown
+++ b/README.markdown
@@ -8,8 +8,6 @@ Any database that has an ActiveRecord adapter should work.  This gem is now Rail
 
 [![Build Status](https://secure.travis-ci.org/ludicast/yaml_db.png)](http://travis-ci.org/ludicast/yaml_db)
 
-Note: This fork aims at getting it works with Rails 4 and the postgresql augmented capacity of having array and hash fields. The branch is named rails4 and is now merge into master.
-
 ## Installation
 
 Simply add to your Gemfile:

--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ Any database that has an ActiveRecord adapter should work.  This gem is now Rail
 
 [![Build Status](https://secure.travis-ci.org/ludicast/yaml_db.png)](http://travis-ci.org/ludicast/yaml_db)
 
-Note: This fork aims at getting it works with Rails 4 and the postgresql augmented capacity of having array and hash fields. The branch is named rails4.
+Note: This fork aims at getting it works with Rails 4 and the postgresql augmented capacity of having array and hash fields. The branch is named rails4 and is now merge into master.
 
 ## Installation
 

--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,8 @@ Any database that has an ActiveRecord adapter should work.  This gem is now Rail
 
 [![Build Status](https://secure.travis-ci.org/ludicast/yaml_db.png)](http://travis-ci.org/ludicast/yaml_db)
 
+Note: This fork aims at getting it works with Rails 4 and the postgresql augmented capacity of having array and hash fields. The branch is named rails4.
+
 ## Installation
 
 Simply add to your Gemfile:

--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -122,7 +122,7 @@ module SerializationHelper
     end
 
     def self.array_columns(table)
-      columns = ActiveRecord::Base.connection.columns(table).reject { |c| silence_warnings { c.type != :array } }
+      columns = ActiveRecord::Base.connection.columns(table).reject { |c| silence_warnings { !c.try(:array) } }
       columns.map { |c| c.name }
     end
 

--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -114,8 +114,8 @@ module SerializationHelper
     def self.convert_arrays(records, columns)
       records.each do |record|
         columns.each do |column|
-          next unless is_array(record[column])
-          record[column] = convert_array(record[column])
+          next unless is_array(record[column[0]])
+          record[column[0]] = convert_array(record[column[0]], column[1])
         end
       end
       records
@@ -123,11 +123,15 @@ module SerializationHelper
 
     def self.array_columns(table)
       columns = ActiveRecord::Base.connection.columns(table).reject { |c| silence_warnings { !c.try(:array) } }
-      columns.map { |c| c.name }
+      columns.map { |c| [ c.name, c.sql_type.to_sym ] }
     end
 
-    def self.convert_array(value)
-      value[1..-2].split(',')
+    def self.convert_array(value, type)
+      if type == :integer
+        value[1..-2].split(',').map { |v| v.to_i}
+      else
+        value[1..-2].split(',')
+      end
     end
 
     def self.is_array(value)

--- a/lib/yaml_db.rb
+++ b/lib/yaml_db.rb
@@ -44,8 +44,8 @@ module YamlDb
       column_names = table_column_names(table)
 
       each_table_page(table) do |records|
-        rows = SerializationHelper::Utils.unhash_records(records, column_names)
-        io.write(YamlDb::Utils.chunk_records(records))
+        rows = SerializationHelper::Utils.unhash_records(records.to_a, column_names)
+        io.write(YamlDb::Utils.chunk_records(rows))
       end
     end
 

--- a/spec/yaml_postgresql_dump_spec.rb
+++ b/spec/yaml_postgresql_dump_spec.rb
@@ -6,7 +6,7 @@ describe YamlDb::Dump do
     silence_warnings { ActiveRecord::Base = mock('ActiveRecord::Base', :null_object => true) }
     ActiveRecord::Base.stub(:connection).and_return(stub('connection').as_null_object)
     ActiveRecord::Base.connection.stub!(:tables).and_return([ 'mytable', 'schema_info', 'schema_migrations' ])
-    ActiveRecord::Base.connection.stub!(:columns).with('mytable').and_return([ mock('a',:name => 'a', :type => :string), mock('b', :name => 'b', :type => :array) ])
+    ActiveRecord::Base.connection.stub!(:columns).with('mytable').and_return([ mock('a',:name => 'a', :type => :string, :array =>false), mock('b', :name => 'b', :type => :string, :array => true) ])
     ActiveRecord::Base.connection.stub!(:select_one).and_return({"count"=>"2"})
     ActiveRecord::Base.connection.stub!(:select_all).and_return([ { 'a' => 1, 'b' => '{}' }, { 'a' => 3, 'b' => '{aa,bb,cc}' } ])
     YamlDb::Utils.stub!(:quote_table).with('mytable').and_return('mytable')
@@ -46,7 +46,7 @@ EOYAML
     YamlDb::Dump.dump_table_records(@io, 'mytable')
     @io.rewind
     @io.read.should == <<EOYAML
-  records:
+  records: 
   - - 1
     - []
   - - 3

--- a/spec/yaml_postgresql_dump_spec.rb
+++ b/spec/yaml_postgresql_dump_spec.rb
@@ -6,9 +6,18 @@ describe YamlDb::Dump do
     silence_warnings { ActiveRecord::Base = mock('ActiveRecord::Base', :null_object => true) }
     ActiveRecord::Base.stub(:connection).and_return(stub('connection').as_null_object)
     ActiveRecord::Base.connection.stub!(:tables).and_return([ 'mytable', 'schema_info', 'schema_migrations' ])
-    ActiveRecord::Base.connection.stub!(:columns).with('mytable').and_return([ mock('a',:name => 'a', :type => :string, :sql_type => 'string', :array => false), mock('b', :name => 'b', :type => :integer, :sql_type => 'integer', :array => true), mock('c', :name => 'c', :type => :string, :sql_type => 'string', :array => true) ])
+    ActiveRecord::Base.connection.stub!(:columns).with('mytable').and_return([
+      mock('a', :name => 'a', :type => :string,  :array => false),
+      mock('b', :name => 'b', :type => :integer, :array => true ),
+      mock('c', :name => 'c', :type => :string,  :array => true ),
+      mock('c', :name => 'd', :type => :boolean, :array => true ),
+      mock('c', :name => 'e', :type => :hstore,  :array => false)
+    ])
     ActiveRecord::Base.connection.stub!(:select_one).and_return({"count"=>"2"})
-    ActiveRecord::Base.connection.stub!(:select_all).and_return([ { 'a' => 1, 'b' => '{}', 'c' => '{}' }, { 'a' => 3, 'b' => '{1,2,3}', 'c' => '{aa,bb,cc}' } ])
+    ActiveRecord::Base.connection.stub!(:select_all).and_return([
+      { 'a' => 1, 'b' => '{}',      'c' => '{}',         'd' => '{false,true,true,false}', 'e' => '' },
+      { 'a' => 3, 'b' => '{1,2,3}', 'c' => '{aa,bb,cc}', 'd' => '{false}',                 'e' => '"aa"=>"1", "bb"=>"2", "cc"=>"3"' }
+    ])
     YamlDb::Utils.stub!(:quote_table).with('mytable').and_return('mytable')
   end
 
@@ -50,6 +59,11 @@ EOYAML
   - - 1
     - []
     - []
+    - - false
+      - true
+      - true
+      - false
+    - {}
   - - 3
     - - 1
       - 2
@@ -57,6 +71,10 @@ EOYAML
     - - aa
       - bb
       - cc
+    - - false
+    - aa: '1'
+      bb: '2'
+      cc: '3'
 EOYAML
   end
 end

--- a/spec/yaml_postgresql_dump_spec.rb
+++ b/spec/yaml_postgresql_dump_spec.rb
@@ -6,9 +6,9 @@ describe YamlDb::Dump do
     silence_warnings { ActiveRecord::Base = mock('ActiveRecord::Base', :null_object => true) }
     ActiveRecord::Base.stub(:connection).and_return(stub('connection').as_null_object)
     ActiveRecord::Base.connection.stub!(:tables).and_return([ 'mytable', 'schema_info', 'schema_migrations' ])
-    ActiveRecord::Base.connection.stub!(:columns).with('mytable').and_return([ mock('a',:name => 'a', :type => :string, :array =>false), mock('b', :name => 'b', :type => :string, :array => true) ])
+    ActiveRecord::Base.connection.stub!(:columns).with('mytable').and_return([ mock('a',:name => 'a', :type => :string, :sql_type => 'string', :array => false), mock('b', :name => 'b', :type => :integer, :sql_type => 'integer', :array => true), mock('c', :name => 'c', :type => :string, :sql_type => 'string', :array => true) ])
     ActiveRecord::Base.connection.stub!(:select_one).and_return({"count"=>"2"})
-    ActiveRecord::Base.connection.stub!(:select_all).and_return([ { 'a' => 1, 'b' => '{}' }, { 'a' => 3, 'b' => '{aa,bb,cc}' } ])
+    ActiveRecord::Base.connection.stub!(:select_all).and_return([ { 'a' => 1, 'b' => '{}', 'c' => '{}' }, { 'a' => 3, 'b' => '{1,2,3}', 'c' => '{aa,bb,cc}' } ])
     YamlDb::Utils.stub!(:quote_table).with('mytable').and_return('mytable')
   end
 
@@ -49,7 +49,11 @@ EOYAML
   records: 
   - - 1
     - []
+    - []
   - - 3
+    - - 1
+      - 2
+      - 3
     - - aa
       - bb
       - cc

--- a/spec/yaml_postgresql_dump_spec.rb
+++ b/spec/yaml_postgresql_dump_spec.rb
@@ -1,0 +1,58 @@
+require File.dirname(__FILE__) + '/base'
+
+describe YamlDb::Dump do
+
+  before do
+    silence_warnings { ActiveRecord::Base = mock('ActiveRecord::Base', :null_object => true) }
+    ActiveRecord::Base.stub(:connection).and_return(stub('connection').as_null_object)
+    ActiveRecord::Base.connection.stub!(:tables).and_return([ 'mytable', 'schema_info', 'schema_migrations' ])
+    ActiveRecord::Base.connection.stub!(:columns).with('mytable').and_return([ mock('a',:name => 'a', :type => :string), mock('b', :name => 'b', :type => :array) ])
+    ActiveRecord::Base.connection.stub!(:select_one).and_return({"count"=>"2"})
+    ActiveRecord::Base.connection.stub!(:select_all).and_return([ { 'a' => 1, 'b' => '{}' }, { 'a' => 3, 'b' => '{aa,bb,cc}' } ])
+    YamlDb::Utils.stub!(:quote_table).with('mytable').and_return('mytable')
+  end
+
+  before(:each) do
+    File.stub!(:new).with('dump.yml', 'w').and_return(StringIO.new)
+    @io = StringIO.new
+  end
+
+  it "should return a formatted string" do
+    YamlDb::Dump.table_record_header(@io)
+    @io.rewind
+    @io.read.should == "  records: \n"
+  end
+
+
+  it "should return a yaml string that contains a table header and column names" do
+    if RUBY_VERSION.split(".")[1] == "9"
+
+      YAML::ENGINE.yamler = "syck"
+    end
+    YamlDb::Dump.stub!(:table_column_names).with('mytable').and_return([ 'a', 'b' ])
+    YamlDb::Dump.dump_table_columns(@io, 'mytable')
+    @io.rewind
+    @io.read.should == <<EOYAML
+
+---
+mytable:
+  columns:
+  - a
+  - b
+EOYAML
+  end
+
+  it "should return dump the records for a postgresql table in yaml to a given io stream" do
+    YamlDb::Dump.dump_table_records(@io, 'mytable')
+    @io.rewind
+    @io.read.should == <<EOYAML
+  records:
+  - - 1
+    - []
+  - - 3
+    - - aa
+      - bb
+      - cc
+EOYAML
+  end
+end


### PR DESCRIPTION
This is an update to support Rails4 (using the modification proposed by edwardvalentini in his own fork) and the use of array fields and hstore fields as supplied by PostgreSQL.

The Rails4 modification may render yaml_db unusable with older versions of rails (this needs to be verified). The PostgreSQL support changes are compatible with other kind of database systems. That doesn't mean it supply support for array and hstore fields for other database systems...

Cheers!

Guy
