### PR TITLE
Include "TRUE" string in SerializationHelper::convert_boolean

### DIFF
--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -122,7 +122,7 @@ module YamlDb
       end
 
       def self.convert_boolean(value)
-        ['t', '1', true, 1].include?(value)
+        ['t', '1', true, 1, 'TRUE'].include?(value)
       end
 
       def self.boolean_columns(table)

--- a/spec/yaml_db/serialization_helper_utils_spec.rb
+++ b/spec/yaml_db/serialization_helper_utils_spec.rb
@@ -49,6 +49,11 @@ module YamlDb
         expect(Utils.convert_boolean(0)).to be false
       end
 
+      it "converts ruby strings TRUE and FALSE to true and false" do
+        expect(Utils.convert_boolean('TRUE')).to be true
+        expect(Utils.convert_boolean('FALSE')).to be false
+      end
+
     end
   end
 end


### PR DESCRIPTION
I'm currently testing H2 to MySQL migration. Works fine, except the boolean values are all false when migrating from H2 to MySQL.
The reason is simple. H2 databases write boolean values as strings with capital letters (e.g "TRUE").

Adding the "TRUE" String to the ::convert_boolean method fixes this problem.

Signed-off-by: Jason Franklin franklin@equinux.com
