### PR TITLE
Added support for single table dump/load with a parameter on the rake ta...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,11 @@ Further, there are tasks db:dump and db:load which do the entire database (the e
     rake db:data:dump_dir   ->   Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)
     rake db:data:load_dir   ->   Load contents of db/data_dir into database
 
+If you would like to limit a database dump or load to a single table add a table parameter to the rake task.
+
+    rake db:data:dump["table_name"]   ->   Dump contents of Rails database table "table_name" to db/data.yml
+    rake db:data:load["table_name"]   ->   Load contents of db/data.yml into the database table "table_name"
+
 In addition, we have plugins whereby you can export your database to/from various formats.  We only deal with yaml and csv right now, but you can easily write tools for your own formats (such as Excel or XML).  To use another format, just load setting the "class"  parameter to the class you are using.  This defaults to "YamlDb::Helper" which is a refactoring of the old yaml_db code.  We'll shorten this to use class nicknames in a little bit.
 
 ## Examples

--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -9,9 +9,9 @@ module SerializationHelper
       @extension = helper.extension
     end
 
-    def dump(filename)
+    def dump(filename, table = nil)
       disable_logger
-      @dumper.dump(File.new(filename, "w"))
+      @dumper.dump(File.new(filename, "w"), table)
       reenable_logger
     end
 
@@ -26,9 +26,9 @@ module SerializationHelper
       end
     end
 
-    def load(filename, truncate = true)
+    def load(filename, truncate = true, table = nil)
       disable_logger
-      @loader.load(File.new(filename, "r"), truncate)
+      @loader.load(File.new(filename, "r"), truncate, table)
       reenable_logger
     end
 
@@ -52,7 +52,7 @@ module SerializationHelper
   end
   
   class Load
-    def self.load(io, truncate = true)
+    def self.load(io, truncate = true, table = nil)
       ActiveRecord::Base.connection.transaction do
         load_documents(io, truncate)
       end
@@ -145,7 +145,13 @@ module SerializationHelper
 
     end
 
-    def self.dump(io)
+    def self.dump(io, table=nil)
+      if table
+        before_table(io, table)
+        dump_table(io, table)
+        after_table(io, table)
+        return
+      end
       tables.each do |table|
         before_table(io, table)
         dump_table(io, table)

--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -15,28 +15,28 @@ namespace :db do
     end
 
     desc "Dump contents of database to db/data.extension (defaults to yaml)"
-    task :dump => :environment do
+    task :dump, [:table] => :environment do |t, args|
       format_class = ENV['class'] || "YamlDb::Helper"
       helper = format_class.constantize
-      SerializationHelper::Base.new(helper).dump db_dump_data_file helper.extension
+      SerializationHelper::Base.new(helper).dump(db_dump_data_file, args[:table])
     end
 
     desc "Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)"
-    task :dump_dir => :environment do
+    task :dump_dir, [:table] => :environment do |t, args|
       format_class = ENV['class'] || "YamlDb::Helper"
       dir = ENV['dir'] || "#{Time.now.to_s.gsub(/ /, '_')}"
       SerializationHelper::Base.new(format_class.constantize).dump_to_dir dump_dir("/#{dir}")
     end
 
     desc "Load contents of db/data.extension (defaults to yaml) into database"
-    task :load => :environment do
+    task :load, [:table] => :environment do |t, args|
       format_class = ENV['class'] || "YamlDb::Helper"
       helper = format_class.constantize
-      SerializationHelper::Base.new(helper).load(db_dump_data_file helper.extension)
+      SerializationHelper::Base.new(helper).load(db_dump_data_file, helper.extension, args[:table])
     end
 
     desc "Load contents of db/data_dir into database"
-    task :load_dir  => :environment do
+    task :load_dir, [:table]  => :environment do |t, args|
       dir = ENV['dir'] || "base"
       format_class = ENV['class'] || "YamlDb::Helper"
       SerializationHelper::Base.new(format_class.constantize).load_from_dir dump_dir("/#{dir}")

--- a/lib/yaml_db.rb
+++ b/lib/yaml_db.rb
@@ -56,10 +56,16 @@ module YamlDb
   end
 
   class Load < SerializationHelper::Load
-    def self.load_documents(io, truncate = true)
+    def self.load_documents(io, truncate = true, table)
         YAML.load_documents(io) do |ydoc|
           ydoc.keys.each do |table_name|
             next if ydoc[table_name].nil?
+            if table
+              if table==table_name
+                load_table(table_name, ydoc[table_name], truncate)
+                return
+              end
+            end
             load_table(table_name, ydoc[table_name], truncate)
           end
         end


### PR DESCRIPTION
I decided to add support for serializing and de-serializing a single table and modified the existing rake tasks dump and load to accept a "table name" parameter.  I was motivated to make this change because on several occasions I only needed to serialize/de-serialize a single table in a large database.
