### PR TITLE
Fix bug affecting sqlite3 date fields: Date columns are now converted to YYYY-MM-DD format

### DIFF
--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -94,7 +94,9 @@ module YamlDb
             end
             ActiveRecord::Base.connection.quote(val, c.last)
           end.join(',')
-          ActiveRecord::Base.connection.execute("INSERT INTO #{quoted_table_name} (#{quoted_column_names}) VALUES (#{quoted_values})")
+          sql = "INSERT INTO #{quoted_table_name} (#{quoted_column_names}) VALUES (#{quoted_values})"
+          #puts "SQL: #{sql}"
+          ActiveRecord::Base.connection.execute(sql)
         end
       end
 


### PR DESCRIPTION
Dumping from MySQL and loading to sqlite3 was failing for me.

Sqlite3 doesn't have native date formats (afaik), so rails deals with that by storing dates as iso8601 (YYYY-MM-DD HH:MM:SS etc) in sqlite3. 

It turns out it was because dates would get dumped from mysql to the yaml file in a format like "Mar 23, 2015", which then got imported straight into sqlite as a string. This made a lot of rails date handling silently and subtly fail, because rails seems to rely on lexical ordering of date fields to work.

This commit fixes that problem, by adding the same type of conversion as happens for booleans - it takes all the date fields and converts them to YYYY-MM-DD. Datetime seemed unaffected by this problem, so I only deal with date.

I haven't checked it extensively for side effects, but it passes the yaml_db unit tests, and I suspect this is a reasonably correct approach that should work with other dbs.
