### PR TITLE
File flushing fix

### DIFF
--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -12,7 +12,9 @@ module YamlDb
 
       def dump(filename)
         disable_logger
-        @dumper.dump(File.new(filename, "w"))
+        File.open(filename, "w") do |file|
+          @dumper.dump(file)
+        end
         reenable_logger
       end
 
@@ -20,10 +22,11 @@ module YamlDb
         Dir.mkdir(dirname)
         tables = @dumper.tables
         tables.each do |table|
-          io = File.new "#{dirname}/#{table}.#{@extension}", "w"
-          @dumper.before_table(io, table)
-          @dumper.dump_table io, table
-          @dumper.after_table(io, table)
+          File.open("#{dirname}/#{table}.#{@extension}", "w") do |io|
+            @dumper.before_table(io, table)
+            @dumper.dump_table io, table
+            @dumper.after_table(io, table)
+          end
         end
       end
 

--- a/spec/yaml_db/dump_spec.rb
+++ b/spec/yaml_db/dump_spec.rb
@@ -11,7 +11,7 @@ module YamlDb
     end
 
     before(:each) do
-      allow(File).to receive(:new).with('dump.yml', 'w').and_return(StringIO.new)
+      allow(File).to receive(:open).with('dump.yml', 'w').and_yield(StringIO.new)
       @io = StringIO.new
     end
 

--- a/spec/yaml_db/serialization_helper_base_spec.rb
+++ b/spec/yaml_db/serialization_helper_base_spec.rb
@@ -24,7 +24,7 @@ module YamlDb
 
       context "for multi-file dumps" do
         before do
-          expect(File).to receive(:new).once.with("dir_name/mytable.yml", "w").and_return(@io)
+          expect(File).to receive(:open).once.with("dir_name/mytable.yml", "w").and_yield(@io)
           expect(Dir).to receive(:mkdir).once.with("dir_name")
           stub_helper!
           expect(@dumper).to receive(:dump_table).once.with(@io, "mytable")

--- a/spec/yaml_db/serialization_helper_dump_spec.rb
+++ b/spec/yaml_db/serialization_helper_dump_spec.rb
@@ -12,7 +12,7 @@ module YamlDb
       end
 
       before(:each) do
-        allow(File).to receive(:new).with('dump.yml', 'w').and_return(StringIO.new)
+        allow(File).to receive(:open).with('dump.yml', 'w').and_yield(StringIO.new)
         @io = StringIO.new
       end
 


### PR DESCRIPTION
Use the block form of `File.open` when writing to a file.  This ensures that the
file gets flushed to disk when finished.

This is a problem when running tasks like `Rake::Task['db:data:dump'].invoke`.

It hasn't been not a problem for `rake db:data:dump` because open files get
flushed automatically when rake finishes and ruby terminates.