### PR TITLE
Fix CI dependency problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,5 @@ matrix:
       rvm: 1.8.7
     - env: RAILS_VERSION='~> 4.2.0'
       rvm: 1.9.2
+before_install:
+  - gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'rails', ENV['RAILS_VERSION']
 
 # Use older gems for older Rubies
-if RUBY_VERSION =~ /^1\.8\.7/ || RUBY_VERSION =~ /^1\.9\.2/
+if RUBY_VERSION.start_with?('1.8.7', '1.9.2')
   gem 'i18n', '~> 0.6.4'
   gem 'rack-cache', '1.2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gemspec
 
 gem 'rails', ENV['RAILS_VERSION']
 
-# Hold i18n back for older Rubies
+# Use older gems for older Rubies
 if RUBY_VERSION =~ /^1\.8\.7/ || RUBY_VERSION =~ /^1\.9\.2/
   gem 'i18n', '~> 0.6.4'
+  gem 'rack-cache', '1.2'
 end


### PR DESCRIPTION
* rack-cache > 1.2 is incompatible with Ruby < 1.9.3 ([example failure](https://travis-ci.org/yamldb/yaml_db/jobs/100616120#L154))
* Some older bundler versions are affected by https://github.com/bundler/bundler/issues/3558, which was fixed in bundler/bundler@a0c90cd53a436b1856c8bcfbdaa44997870e4488 ([example failure](https://travis-ci.org/yamldb/yaml_db/jobs/100629547#L167))