### PR TITLE
Adds ability to load yaml files without truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ Further, there are tasks db:dump and db:load which do the entire database (the e
     rake db:data:dump_dir   ->   Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)
     rake db:data:load_dir   ->   Load contents of db/data_dir into database
 
+
 In addition, we have plugins whereby you can export your database to/from various formats.  We only deal with yaml and csv right now, but you can easily write tools for your own formats (such as Excel or XML).  To use another format, just load setting the "class"  parameter to the class you are using.  This defaults to "YamlDb::Helper" which is a refactoring of the old yaml_db code.  We'll shorten this to use class nicknames in a little bit.
+
+If you do not want to truncate the table, you can set this as an environment variable
+
+    rake db:data:load_no_truncate
+    rake db:data:load_dir_no_truncate
 
 ## Examples
 

--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -25,5 +25,15 @@ namespace :db do
     task :load_dir  => :environment do
       YamlDb::RakeTasks.data_load_dir_task
     end
+
+    desc "Load contents of db/data.extension (defaults to yaml) into database without truncating tables"
+    task :load_no_truncate => :environment do
+      YamlDb::RakeTasks.data_load_task(false)
+    end
+
+    desc "Load contents of db/data_dir into database without truncating tables"
+    task :load_dir_no_truncate  => :environment do
+      YamlDb::RakeTasks.data_load_dir_task(false)
+    end
   end
 end

--- a/lib/yaml_db/rake_tasks.rb
+++ b/lib/yaml_db/rake_tasks.rb
@@ -9,13 +9,13 @@ module YamlDb
       SerializationHelper::Base.new(helper).dump_to_dir(dump_dir("/#{dir}"))
     end
 
-    def self.data_load_task
-      SerializationHelper::Base.new(helper).load(db_dump_data_file(helper.extension))
+    def self.data_load_task(truncate = true)
+      SerializationHelper::Base.new(helper).load(db_dump_data_file(helper.extension), truncate)
     end
 
-    def self.data_load_dir_task
+    def self.data_load_dir_task(truncate = true)
       dir = ENV['dir'] || 'base'
-      SerializationHelper::Base.new(helper).load_from_dir(dump_dir("/#{dir}"))
+      SerializationHelper::Base.new(helper).load_from_dir(dump_dir("/#{dir}"), truncate)
     end
 
     private

--- a/spec/tasks/yaml_db_tasks_spec.rb
+++ b/spec/tasks/yaml_db_tasks_spec.rb
@@ -63,4 +63,26 @@ RSpec.describe 'Rake tasks' do
       subject.invoke
     end
   end
+
+  describe 'db:data:load_no_truncate' do
+    it 'loads the environment' do
+      expect(subject.prerequisites).to eq(['environment'])
+    end
+
+    it 'invokes the correct task' do
+      expect(YamlDb::RakeTasks).to receive(:data_load_task).once.with(false)
+      subject.invoke
+    end
+  end
+
+  describe 'db:data:load_dir_no_truncate' do
+    it 'loads the environment' do
+      expect(subject.prerequisites).to eq(['environment'])
+    end
+
+    it 'invokes the correct task' do
+      expect(YamlDb::RakeTasks).to receive(:data_load_dir_task).once.with(false)
+      subject.invoke
+    end
+  end
 end

--- a/spec/yaml_db/rake_tasks_spec.rb
+++ b/spec/yaml_db/rake_tasks_spec.rb
@@ -49,14 +49,20 @@ module YamlDb
     describe '.data_load_task' do
       it 'loads a file' do
         expect(SerializationHelper::Base).to receive(:new).once.with(Helper)
-        expect(@serializer).to receive(:load).once.with('/root/db/data.yml')
+        expect(@serializer).to receive(:load).once.with('/root/db/data.yml', true)
         RakeTasks.data_load_task
+      end
+
+      it 'loads a file without truncating the table' do
+        expect(SerializationHelper::Base).to receive(:new).once.with(Helper)
+        expect(@serializer).to receive(:load).once.with('/root/db/data.yml', false)
+        RakeTasks.data_load_task(false)
       end
 
       it 'loads a file using a user-specified format class' do
         stub_const('ENV', 'class' => 'UserSpecifiedHelper')
         expect(SerializationHelper::Base).to receive(:new).once.with(UserSpecifiedHelper)
-        expect(@serializer).to receive(:load).once.with('/root/db/data.ext')
+        expect(@serializer).to receive(:load).once.with('/root/db/data.ext', true)
         RakeTasks.data_load_task
       end
     end
@@ -64,21 +70,27 @@ module YamlDb
     describe '.data_load_dir_task' do
       it 'loads a directory' do
         expect(SerializationHelper::Base).to receive(:new).once.with(Helper)
-        expect(@serializer).to receive(:load_from_dir).once.with('/root/db/base')
+        expect(@serializer).to receive(:load_from_dir).once.with('/root/db/base', true)
         RakeTasks.data_load_dir_task
+      end
+
+      it 'loads a directory without truncating the file' do
+        expect(SerializationHelper::Base).to receive(:new).once.with(Helper)
+        expect(@serializer).to receive(:load_from_dir).once.with('/root/db/base', false)
+        RakeTasks.data_load_dir_task(false)
       end
 
       it 'loads a directory using a user-specified format class' do
         stub_const('ENV', 'class' => 'UserSpecifiedHelper')
         expect(SerializationHelper::Base).to receive(:new).once.with(UserSpecifiedHelper)
-        expect(@serializer).to receive(:load_from_dir).once.with('/root/db/base')
+        expect(@serializer).to receive(:load_from_dir).once.with('/root/db/base', true)
         RakeTasks.data_load_dir_task
       end
 
       it 'loads a user-specified directory' do
         stub_const('ENV', 'dir' => 'user_dir')
         expect(SerializationHelper::Base).to receive(:new).once.with(Helper)
-        expect(@serializer).to receive(:load_from_dir).once.with('/root/db/user_dir')
+        expect(@serializer).to receive(:load_from_dir).once.with('/root/db/user_dir', true)
         RakeTasks.data_load_dir_task
       end
     end


### PR DESCRIPTION
- Add two new rake tasks with a `_no_truncate` on the end of `load` and `load_dir`
- Add covering specs
- Update other specs to handle passing true to the `SerializationHelper`
