### PR TITLE
Feature/exclude tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Further, there are tasks db:dump and db:load which do the entire database (the e
 
 In addition, we have plugins whereby you can export your database to/from various formats.  We only deal with yaml and csv right now, but you can easily write tools for your own formats (such as Excel or XML).  To use another format, just load setting the "class"  parameter to the class you are using.  This defaults to "YamlDb::Helper" which is a refactoring of the old yaml_db code.  We'll shorten this to use class nicknames in a little bit.
 
+## Optional parameters
+
+    dir='some_directory_name'           ->  Specify the name of the target dump directory
+    exclude=[\"table_1\", \"table_2\"]  ->  Specify tables in JSON array format to exclude
+
 ## Examples
 
 One common use would be to switch your data from one database backend to another.  For example, let's say you wanted to switch from SQLite to MySQL.  You might execute the following steps:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ In addition, we have plugins whereby you can export your database to/from variou
 
 ## Optional parameters
 
-    dir='some_directory_name'           ->  Specify the name of the target dump directory
-    exclude=[\"table_1\", \"table_2\"]  ->  Specify tables in JSON array format to exclude
+    dir='some_directory_name'  ->  Specify the name of the target dump directory
+    exclude="table_1,table_2"  ->  Specify tables in comma delimited format to exclude
 
 ## Examples
 

--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -162,7 +162,7 @@ module YamlDb
 
       def self.tables
         response = ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }
-        excludes = JSON.parse(ENV["exclude"]) || []
+        excludes = JSON.parse( ENV["exclude"] || "[]" )
         excludes.each do |exclude|
           response.delete(exclude)
         end

--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -161,7 +161,12 @@ module YamlDb
       end
 
       def self.tables
-        ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }
+        response = ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }
+        excludes = JSON.parse(ENV["exclude"]) || []
+        excludes.each do |exclude|
+          response.delete(exclude)
+        end
+        return response
       end
 
       def self.dump_table(io, table)

--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -162,11 +162,8 @@ module YamlDb
 
       def self.tables
         response = ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }
-        excludes = JSON.parse( ENV["exclude"] || "[]" )
-        excludes.each do |exclude|
-          response.delete(exclude)
-        end
-        return response
+        excludes = ( ENV["exclude"] || "" ).split(",")
+        return (response - excludes)
       end
 
       def self.dump_table(io, table)

--- a/spec/yaml_db/serialization_helper_dump_spec.rb
+++ b/spec/yaml_db/serialization_helper_dump_spec.rb
@@ -59,6 +59,11 @@ module YamlDb
         Dump.dump_table(@io, 'mytable')
       end
 
+      it 'does not dump table that is excluded' do
+        stub_const('ENV', 'exclude' => '["mytable"]')
+        expect(Dump.tables).to eq([])
+      end
+
     end
   end
 end

--- a/spec/yaml_db/serialization_helper_dump_spec.rb
+++ b/spec/yaml_db/serialization_helper_dump_spec.rb
@@ -60,7 +60,7 @@ module YamlDb
       end
 
       it 'does not dump table that is excluded' do
-        stub_const('ENV', 'exclude' => '["mytable"]')
+        stub_const('ENV', 'exclude' => "mytable")
         expect(Dump.tables).to eq([])
       end
 


### PR DESCRIPTION
Allows the user to specify tables via a comma delimited parameter to not include in the data:dump / data:dump_dir.

Example rake db:data:dump_dir dir="my_dir" exclude="table_1,table_2"
