### PR TITLE
Use OS independent dir name format

### DIFF
--- a/lib/yaml_db/rake_tasks.rb
+++ b/lib/yaml_db/rake_tasks.rb
@@ -5,7 +5,7 @@ module YamlDb
     end
 
     def self.data_dump_dir_task
-      dir = ENV['dir'] || "#{Time.now.strftime('%F_%T')}"
+      dir = ENV['dir'] || "#{Time.now.strftime('%F_%H.%M.%S')}"
       SerializationHelper::Base.new(helper).dump_to_dir(dump_dir("/#{dir}"))
     end
 


### PR DESCRIPTION
Change to dir name format that uses  .  rather than  :  so that it will work in all operating systems.

puts "#{Time.now.strftime('%F_%T')}"      >>>>         2016-07-26_22:41:12
puts "#{Time.now.strftime('%F_%H.%M.%S')}" >>>> 2016-07-26_22.41.12