### PR TITLE
fixed support for streaming documents

### DIFF
--- a/lib/yaml_db.rb
+++ b/lib/yaml_db.rb
@@ -59,7 +59,7 @@ module YamlDb
 
   class Load < SerializationHelper::Load
     def self.load_documents(io, truncate = true)
-        YAML.load_documents(io) do |ydoc|
+        YAML.load_stream(io) do |ydoc|
           ydoc.keys.each do |table_name|
             next if ydoc[table_name].nil?
             load_table(table_name, ydoc[table_name], truncate)


### PR DESCRIPTION
The YAML.load_documents method is deprecated.  In the source code, it calls load_stream to get it's result.  This implementation means that blocks are not properly handled, and thus all documents in the YAML file get loaded into memory.  Calling load_stream instead allows the passing of blocks, and thus allows actual streaming, decreasing memory usage.
