### PR TITLE
Sort Key for HABTM should be comma seperated string instead of Array

### DIFF
--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -189,6 +189,7 @@ module YamlDb
 
         (0..pages).to_a.each do |page|
           query = Arel::Table.new(table).order(key).skip(records_per_page*page).take(records_per_page).project(Arel.sql('*'))
+
           records = ActiveRecord::Base.connection.select_all(query.to_sql)
           records = Utils.convert_booleans(records, boolean_columns)
           yield records
@@ -205,7 +206,7 @@ module YamlDb
         first_column, second_column = table_column_names(table)
 
         if [first_column, second_column].all? { |name| name =~ /_id$/ }
-          [Utils.quote_column(first_column), Utils.quote_column(second_column)]
+          [Utils.quote_column(first_column), Utils.quote_column(second_column)].join(',')
         else
           Utils.quote_column(first_column)
         end

--- a/spec/yaml_db/serialization_helper_dump_spec.rb
+++ b/spec/yaml_db/serialization_helper_dump_spec.rb
@@ -87,7 +87,7 @@ module YamlDb
             double('b_id', :name => 'b_id', :type => :string)
           ])
 
-          expect(Dump.sort_key('mytable')).to eq(['a_id', 'b_id'])
+          expect(Dump.sort_key('mytable')).to eq('a_id,b_id')
         end
 
         it "quotes the column name" do


### PR DESCRIPTION
This was creating issues doing a dump because Arel Table expects a string for the order argument and was receiving an Array. 