### PR TITLE
dump/load selected tables only

### DIFF
--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -16,6 +16,14 @@ namespace :db do
       YamlDb::RakeTasks.data_dump_dir_task
     end
 
+    desc "Dump contents of given tables to db/tables/tablename.extension (defaults to yaml)"
+    task :dump_tables_dir => :environment do
+      tables = ENV['tables'].to_s.split(',').collect(&:strip).compact.uniq
+      dir = ENV['dir'] ||= 'tables'
+      puts "Specify tables via # tables='table1,table2'" if tables.empty?
+      YamlDb::RakeTasks.data_dump_tables_dir_task(tables)
+    end
+
     desc "Load contents of db/data.extension (defaults to yaml) into database"
     task :load => :environment do
       YamlDb::RakeTasks.data_load_task
@@ -25,5 +33,14 @@ namespace :db do
     task :load_dir  => :environment do
       YamlDb::RakeTasks.data_load_dir_task
     end
+
+    desc "Load contents of given tables from db/data_dir (default dir is 'tables') into database"
+    task :load_tables_dir  => :environment do
+      tables = ENV['tables'].to_s.split(',').collect(&:strip).compact.uniq
+      dir = ENV['dir'] ||= 'tables'
+      puts "Specify tables via # tables='table1,table2'" if tables.empty?
+      YamlDb::RakeTasks.data_load_tables_dir_task(tables)
+    end
+
   end
 end

--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -19,7 +19,7 @@ namespace :db do
     desc "Dump contents of given tables to db/tables/tablename.extension (defaults to yaml)"
     task :dump_tables_dir => :environment do
       tables = ENV['tables'].to_s.split(',').collect(&:strip).compact.uniq
-      dir = ENV['dir'] ||= 'tables'
+      ENV['dir'] ||= 'tables'
       puts "Specify tables via # tables='table1,table2'" if tables.empty?
       YamlDb::RakeTasks.data_dump_tables_dir_task(tables)
     end
@@ -37,7 +37,7 @@ namespace :db do
     desc "Load contents of given tables from db/data_dir (default dir is 'tables') into database"
     task :load_tables_dir  => :environment do
       tables = ENV['tables'].to_s.split(',').collect(&:strip).compact.uniq
-      dir = ENV['dir'] ||= 'tables'
+      ENV['dir'] ||= 'tables'
       puts "Specify tables via # tables='table1,table2'" if tables.empty?
       YamlDb::RakeTasks.data_load_tables_dir_task(tables)
     end

--- a/lib/yaml_db/rake_tasks.rb
+++ b/lib/yaml_db/rake_tasks.rb
@@ -4,6 +4,11 @@ module YamlDb
       SerializationHelper::Base.new(helper).dump(db_dump_data_file(helper.extension))
     end
 
+    def self.data_dump_tables_dir_task(tables)
+      helper.dumper.tables = tables
+      data_dump_dir_task
+    end
+
     def self.data_dump_dir_task
       dir = ENV['dir'] || default_dir_name
       SerializationHelper::Base.new(helper).dump_to_dir(dump_dir("/#{dir}"))
@@ -11,6 +16,11 @@ module YamlDb
 
     def self.data_load_task
       SerializationHelper::Base.new(helper).load(db_dump_data_file(helper.extension))
+    end
+
+    def self.data_load_tables_dir_task(tables)
+      helper.dumper.tables = tables
+      data_load_dir_task
     end
 
     def self.data_load_dir_task

--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -164,8 +164,12 @@ module YamlDb
 
       end
 
+      def self.tables=(tables)
+        @@tables = tables
+      end
+
       def self.tables
-        ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }.sort
+        @@tables ||= ActiveRecord::Base.connection.tables.reject { |table| ['schema_info', 'schema_migrations'].include?(table) }.sort
       end
 
       def self.dump_table(io, table)


### PR DESCRIPTION
Add functionality to dump and load only specific tables into/from a
directory.

Added a class method to manually set an Array of tables.
New class methods and rake tasks added.

Used like this:
`rake db:data:dump_tables_dir tables='table1,table2' dir='tables'`
`rake db:data:load_tables_dir tables='table1,table2' dir='tables'`