### PR TITLE
Support Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,11 @@ matrix:
       rvm: 2.3.3
     - env: RAILS_VERSION='~> 5.1.0'
       rvm: 2.4.1
+    - env: RAILS_VERSION='~> 5.2.0'
+      rvm: 2.2
+    - env: RAILS_VERSION='~> 5.2.0'
+      rvm: 2.3.3
+    - env: RAILS_VERSION='~> 5.2.0'
+      rvm: 2.4.1
 before_install:
   - gem update bundler

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This can be used as a replacement for mysqldump or pg_dump, but only for the dat
 
 Any database that has an ActiveRecord adapter should work.
 
-This gem supports Rails versions 3.0 through 5.1.
+This gem supports Rails versions 3.0 through 5.2.
 
 [![Build Status](https://travis-ci.org/yamldb/yaml_db.svg?branch=master)](https://travis-ci.org/yamldb/yaml_db)
 

--- a/yaml_db.gemspec
+++ b/yaml_db.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.8.7"
 
-  s.add_runtime_dependency "rails", ">= 3.0", "< 5.2"
+  s.add_runtime_dependency "rails", ">= 3.0"
   s.add_runtime_dependency "rake", ">= 0.8.7"
 
   s.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
I think it makes sense in the README to say that the gem officially
supports only a specific range of Rails versions, but I would
be really happy if we could get rid of the upper-bound gem locking.
It makes it difficult for people to upgrade to the latest version of
Rails, and some people end up creating their own forks to get
around the this. There has been talk among some of the
Rails contributors to avoid gem locking when possible.