### PR TITLE
Add blacklist and whitelist; clean code with Rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+.ruby-gemset
+.ruby-version
 *.gem
 /.bundle/
 /pkg/
+/spec/rspec_status.txt
 Gemfile.lock
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,44 @@
+---
+AllCops:
+  Exclude:
+    - 'Guardfile'
+    - 'bin/**/*'
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'features/support/env.rb'
+    - 'lib/tasks/cucumber.rake'
+    - 'lib/generators/**/*'
+    - 'lib/tasks/ci.rake'
+    - 'lib/yaml_db/rake_tasks.rb'
+    - 'md/**/*'
+    - 'node_modules/**/*'
+    - 'spec/html/**/*'
+    - 'spec/yaml_db/*'
+
+  TargetRubyVersion: 2.5
+
+Layout/EmptyLinesAroundBlockBody:
+  Exclude:
+    - 'spec/factories/**/*'
+    - 'assets/javascripts/rails.validations.js'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+    - 'app/admin/item/item_controller.rb'
+
+Metrics/LineLength:
+  Exclude:
+    - Guardfile
+
+  Max: 105
+
+Rails:
+  Enabled: true
+
+Rails/HttpPositionalArguments:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Style/Documentation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ One common use would be to switch your data from one database backend to another
 
 4. rake db:load
 
+## Options
+
+Two options let you control what tables are dumped: `include` and `exclude`. The former is a
+  whitelist; the latter is a blacklist. If a whitelist is provided, it names the tables to dump
+  (rather than all database tables). Each table mentioned in the blacklist is excluded.
+
+Each list expects a `:`-separated list of table names. For example, the command ...
+
+```
+$ include=users:posts:topics rake db:data:dump
+```
+
+... would dump the `users`, `posts`, and `topics` tables, while ...
+
+```
+$ exclude=hits:versions rake db:data:dump
+```
+
+... would dump all tables except `hits` and `versions`.
+
+You can provide a whitelist and blacklist at the same time, which makes scripting easier. If
+a table appears in both lists, it is excluded. 
+
 ## Credits
 
 Created by Orion Henry and Adam Wiggins. Major updates by Ricardo Chimal Jr. and Nate Kidwell.

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require 'rake'
-require "rspec/core/rake_task"
-require "bundler/gem_tasks"
+require 'rspec/core/rake_task'
+require 'bundler/gem_tasks'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
-
+task default: :spec

--- a/lib/tasks/yaml_db_tasks.rake
+++ b/lib/tasks/yaml_db_tasks.rake
@@ -1,28 +1,30 @@
-namespace :db do
-  desc "Dump schema and data to db/schema.rb and db/data.yml"
-  task(:dump => [ "db:schema:dump", "db:data:dump" ])
+# frozen_string_literal: true
 
-  desc "Load schema and data from db/schema.rb and db/data.yml"
-  task(:load => [ "db:schema:load", "db:data:load" ])
+namespace :db do
+  desc 'Dump schema and data to db/schema.rb and db/data.yml'
+  task(dump: ['db:schema:dump', 'db:data:dump'])
+
+  desc 'Load schema and data from db/schema.rb and db/data.yml'
+  task(load: ['db:schema:load', 'db:data:load'])
 
   namespace :data do
-    desc "Dump contents of database to db/data.extension (defaults to yaml)"
-    task :dump => :environment do
+    desc 'Dump contents of database to db/data.extension (defaults to yaml)'
+    task dump: :environment do
       YamlDb::RakeTasks.data_dump_task
     end
 
-    desc "Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)"
-    task :dump_dir => :environment do
+    desc 'Dump contents of database to curr_dir_name/tablename.extension (defaults to yaml)'
+    task dump_dir: :environment do
       YamlDb::RakeTasks.data_dump_dir_task
     end
 
-    desc "Load contents of db/data.extension (defaults to yaml) into database"
-    task :load => :environment do
+    desc 'Load contents of db/data.extension (defaults to yaml) into database'
+    task load: :environment do
       YamlDb::RakeTasks.data_load_task
     end
 
-    desc "Load contents of db/data_dir into database"
-    task :load_dir  => :environment do
+    desc 'Load contents of db/data_dir into database'
+    task load_dir: :environment do
       YamlDb::RakeTasks.data_load_dir_task
     end
   end

--- a/lib/yaml_db.rb
+++ b/lib/yaml_db.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'yaml'
 require 'active_record'
@@ -17,23 +19,20 @@ module YamlDb
     end
 
     def self.extension
-      "yml"
+      'yml'
     end
   end
 
-
   module Utils
     def self.chunk_records(records)
-      yaml = [ records ].to_yaml
+      yaml = [records].to_yaml
       yaml.sub!(/---\s\n|---\n/, '')
       yaml.sub!('- - -', '  - -')
       yaml
     end
-
   end
 
   class Dump < SerializationHelper::Dump
-
     def self.dump_table_columns(io, table)
       io.write("\n")
       io.write({ table => { 'columns' => table_column_names(table) } }.to_yaml)
@@ -53,25 +52,24 @@ module YamlDb
     def self.table_record_header(io)
       io.write("  records: \n")
     end
-
   end
 
   class Load < SerializationHelper::Load
     def self.load_documents(io, truncate = true)
-        YAML.load_stream(io) do |ydoc|
-          ydoc.keys.each do |table_name|
-            next if ydoc[table_name].nil?
-            load_table(table_name, ydoc[table_name], truncate)
-          end
+      YAML.load_stream(io) do |ydoc|
+        ydoc.keys.each do |table_name|
+          next if ydoc[table_name].nil?
+
+          load_table(table_name, ydoc[table_name], truncate)
         end
+      end
     end
   end
 
   class Railtie < Rails::Railtie
     rake_tasks do
-      load File.expand_path('../tasks/yaml_db_tasks.rake',
-__FILE__)
+      load File.expand_path('tasks/yaml_db_tasks.rake',
+                            __dir__)
     end
   end
-
 end

--- a/lib/yaml_db/rake_tasks.rb
+++ b/lib/yaml_db/rake_tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module YamlDb
   module RakeTasks
     def self.data_dump_task

--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -66,7 +66,7 @@ module YamlDb
 
       def self.truncate_table(table)
         begin
-          ActiveRecord::Base.connection.execute("TRUNCATE #{Utils.quote_table(table)}")
+          ActiveRecord::Base.connection.execute("TRUNCATE #{Utils.quote_table(table)} CASCADE")
         rescue Exception
           ActiveRecord::Base.connection.execute("DELETE FROM #{Utils.quote_table(table)}")
         end

--- a/lib/yaml_db/serialization_helper.rb
+++ b/lib/yaml_db/serialization_helper.rb
@@ -68,7 +68,7 @@ module YamlDb
         begin
           ActiveRecord::Base.connection.execute("TRUNCATE #{Utils.quote_table(table)} CASCADE")
         rescue Exception
-          ActiveRecord::Base.connection.execute("DELETE FROM #{Utils.quote_table(table)}")
+          ActiveRecord::Base.connection.execute("DELETE FROM #{Utils.quote_table(table)} CASCADE")
         end
       end
 

--- a/lib/yaml_db/version.rb
+++ b/lib/yaml_db/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module YamlDb
-  VERSION = "0.7.0"
+  VERSION = '0.7.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 require 'yaml_db'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.example_status_persistence_file_path = 'spec/rspec_status.txt'
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
@@ -10,14 +14,14 @@ RSpec.configure do |config|
     #   # => "be bigger than 2 and smaller than 4"
     # ...rather than:
     #   # => "be bigger than 2"
-    #expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    # expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
   config.mock_with :rspec do |mocks|
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
-    #mocks.verify_partial_doubles = true
+    # mocks.verify_partial_doubles = true
   end
 
   # These two settings work together to allow you to limit a spec run
@@ -51,7 +55,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  #config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/tasks/yaml_db_tasks_spec.rb
+++ b/spec/tasks/yaml_db_tasks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 
 RSpec.describe 'Rake tasks' do

--- a/spec/yaml_db/dump_spec.rb
+++ b/spec/yaml_db/dump_spec.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
+
 module YamlDb
   RSpec.describe Dump do
-
     before do
       allow(ActiveRecord::Base).to receive(:connection).and_return(double('connection').as_null_object)
-      allow(ActiveRecord::Base.connection).to receive(:tables).and_return([ 'mytable', 'schema_info', 'schema_migrations' ])
-      allow(ActiveRecord::Base.connection).to receive(:columns).with('mytable').and_return([ double('a',:name => 'a', :type => :string), double('b', :name => 'b', :type => :string) ])
-      allow(ActiveRecord::Base.connection).to receive(:select_one).and_return({"count"=>"2"})
-      allow(ActiveRecord::Base.connection).to receive(:select_all).and_return([ { 'a' => 1, 'b' => 2 }, { 'a' => 3, 'b' => 4 } ])
+      allow(ActiveRecord::Base.connection).to receive(:tables).and_return(%w[mytable schema_info schema_migrations])
+      allow(ActiveRecord::Base.connection).to receive(:columns).with('mytable').and_return([double('a', name: 'a', type: :string), double('b', name: 'b', type: :string)])
+      allow(ActiveRecord::Base.connection).to receive(:select_one).and_return('count' => '2')
+      allow(ActiveRecord::Base.connection).to receive(:select_all).and_return([{ 'a' => 1, 'b' => 2 }, { 'a' => 3, 'b' => 4 }])
       allow(Utils).to receive(:quote_table).with('mytable').and_return('mytable')
     end
 
@@ -15,40 +16,39 @@ module YamlDb
       @io = StringIO.new
     end
 
-    it "returns a formatted string" do
+    it 'returns a formatted string' do
       Dump.table_record_header(@io)
       @io.rewind
       expect(@io.read).to eq("  records: \n")
     end
 
-    it "returns a yaml string that contains a table header and column names" do
-      allow(Dump).to receive(:table_column_names).with('mytable').and_return([ 'a', 'b' ])
+    it 'returns a yaml string that contains a table header and column names' do
+      allow(Dump).to receive(:table_column_names).with('mytable').and_return(%w[a b])
       Dump.dump_table_columns(@io, 'mytable')
       @io.rewind
       if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9.3')
-        expect(@io.read).to eq(<<EOYAML
+        expect(@io.read).to eq(<<~EOYAML
 
----
-mytable:
-  columns:
-  - a
-  - b
-EOYAML
-        )
+          ---
+          mytable:
+            columns:
+            - a
+            - b
+        EOYAML
+                              )
       else
-        expect(@io.read).to eq(<<EOYAML
-
---- 
-mytable: 
-  columns: 
-  - a
-  - b
-EOYAML
-        )
+        expect(@io.read).to eq(<<~EOYAML
+          ---
+          mytable:
+            columns:
+            - a
+            - b
+        EOYAML
+                              )
       end
     end
 
-    it "dumps the records for a table in yaml to a given io stream" do
+    it 'dumps the records for a table in yaml to a given io stream' do
       allow(SerializationHelper::Dump).to receive(:each_table_page).with('mytable').and_yield(
         [{ 'a' => 1, 'b' => 2 }, { 'a' => 3, 'b' => 4 }]
       )
@@ -61,8 +61,7 @@ EOYAML
   - - 3
     - 4
 EOYAML
-      )
+                            )
     end
-
   end
 end

--- a/spec/yaml_db/integration_spec.rb
+++ b/spec/yaml_db/integration_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'active_record/railtie'
 
 # connect to in-memory SQLite database
 ActiveRecord::Base.establish_connection(
-  :adapter => 'sqlite3',
-  :database => ':memory:'
+  adapter: 'sqlite3',
+  database: ':memory:'
 )
 
 # define a dummy User model
@@ -14,25 +16,23 @@ end
 ActiveRecord::Schema.define do
   self.verbose = false
 
-  create_table :users, :force => true do |t|
+  create_table :users, force: true do |t|
     t.string :username
   end
 end
 
 # add some users
 User.create([
-  {:username => 'alice'},
-  {:username => 'bob'}
-])
+              { username: 'alice' },
+              { username: 'bob' }
+            ])
 
-
-RSpec.describe "with real ActiveRecord," do
-
-  it "contains two users" do
+RSpec.describe 'with real ActiveRecord,' do
+  it 'contains two users' do
     expect(User.count).to eq(2)
   end
 
-  it "dumps the user records" do
+  it 'dumps the user records' do
     @io = StringIO.new
     YamlDb::Dump.dump_table_records(@io, 'users')
     @io.rewind
@@ -43,7 +43,6 @@ RSpec.describe "with real ActiveRecord," do
   - - 2
     - bob
 EOYAML
-    )
+                          )
   end
-
 end

--- a/spec/yaml_db/load_spec.rb
+++ b/spec/yaml_db/load_spec.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 module YamlDb
   RSpec.describe Load do
-
     before do
       allow(SerializationHelper::Utils).to receive(:quote_table).with('mytable').and_return('mytable')
 
@@ -12,20 +13,19 @@ module YamlDb
       @io = StringIO.new
     end
 
-    it "calls load structure for each document in the file" do
-      expect(YAML).to receive(:load_stream).with(@io).and_yield({ 'mytable' => {
-            'columns' => [ 'a', 'b' ],
-            'records' => [[1, 2], [3, 4]]
-          } } )
-      expect(Load).to receive(:load_table).with('mytable', { 'columns' => [ 'a', 'b' ], 'records' => [[1, 2], [3, 4]] },true)
+    it 'calls load structure for each document in the file' do
+      expect(YAML).to receive(:load_stream).with(@io).and_yield('mytable' => {
+                                                                  'columns' => %w[a b],
+                                                                  'records' => [[1, 2], [3, 4]]
+                                                                })
+      expect(Load).to receive(:load_table).with('mytable', { 'columns' => %w[a b], 'records' => [[1, 2], [3, 4]] }, true)
       Load.load(@io)
     end
 
-    it "calls load structure when the document in the file contains no records" do
-      expect(YAML).to receive(:load_stream).with(@io).and_yield({ 'mytable' => nil })
+    it 'calls load structure when the document in the file contains no records' do
+      expect(YAML).to receive(:load_stream).with(@io).and_yield('mytable' => nil)
       expect(Load).not_to receive(:load_table)
       Load.load(@io)
     end
-
   end
 end

--- a/spec/yaml_db/rake_tasks_spec.rb
+++ b/spec/yaml_db/rake_tasks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module YamlDb
   RSpec.describe RakeTasks do
     before do

--- a/spec/yaml_db/serialization_helper_base_spec.rb
+++ b/spec/yaml_db/serialization_helper_base_spec.rb
@@ -1,54 +1,53 @@
+# frozen_string_literal: true
+
 module YamlDb
   module SerializationHelper
     RSpec.describe Base do
-      def prestub_active_record
-      end
+      def prestub_active_record; end
 
       before do
         @io = StringIO.new
         allow(ActiveRecord::Base).to receive(:connection).and_return(double('connection'))
-        allow(ActiveRecord::Base.connection).to receive(:tables).and_return([ 'mytable', 'schema_info', 'schema_migrations' ])
+        allow(ActiveRecord::Base.connection).to receive(:tables).and_return(%w[mytable schema_info schema_migrations])
       end
 
       def stub_helper!
-        @helper = double("MyHelper")
-        @dumper = double("MyDumper");
-        @loader = double("MyLoader");
+        @helper = double('MyHelper')
+        @dumper = double('MyDumper')
+        @loader = double('MyLoader')
         allow(@helper).to receive(:dumper).and_return(@dumper)
         allow(@helper).to receive(:loader).and_return(@loader)
-        allow(@helper).to receive(:extension).and_return("yml")
+        allow(@helper).to receive(:extension).and_return('yml')
         allow(@dumper).to receive(:tables).and_return([ActiveRecord::Base.connection.tables[0]])
         allow(@dumper).to receive(:before_table).and_return(nil)
         allow(@dumper).to receive(:after_table).and_return(nil)
       end
 
-      context "for multi-file dumps" do
+      context 'for multi-file dumps' do
         before do
-          expect(File).to receive(:open).once.with("dir_name/mytable.yml", "w").and_yield(@io)
-          expect(Dir).to receive(:mkdir).once.with("dir_name")
+          expect(File).to receive(:open).once.with('dir_name/mytable.yml', 'w').and_yield(@io)
+          expect(Dir).to receive(:mkdir).once.with('dir_name')
           stub_helper!
-          expect(@dumper).to receive(:dump_table).once.with(@io, "mytable")
+          expect(@dumper).to receive(:dump_table).once.with(@io, 'mytable')
         end
 
-        it "creates the number of files that there are tables" do
-           Base.new(@helper).dump_to_dir "dir_name"
+        it 'creates the number of files that there are tables' do
+          Base.new(@helper).dump_to_dir 'dir_name'
         end
-
       end
 
-      context "for multi-file loads" do
+      context 'for multi-file loads' do
         before do
           stub_helper!
           expect(@loader).to receive(:load).once.with(@io, true)
-          expect(File).to receive(:new).once.with("dir_name/mytable.yml", "r").and_return(@io)
-          allow(Dir).to receive(:entries).and_return(["mytable.yml"])
+          expect(File).to receive(:new).once.with('dir_name/mytable.yml', 'r').and_return(@io)
+          allow(Dir).to receive(:entries).and_return(['mytable.yml'])
         end
 
-        it "inserts into the number of tables that there are files" do
-          Base.new(@helper).load_from_dir "dir_name"
+        it 'inserts into the number of tables that there are files' do
+          Base.new(@helper).load_from_dir 'dir_name'
         end
       end
-
     end
   end
 end

--- a/spec/yaml_db/serialization_helper_load_spec.rb
+++ b/spec/yaml_db/serialization_helper_load_spec.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module YamlDb
   module SerializationHelper
     RSpec.describe Load do
-
       before do
         allow(Utils).to receive(:quote_table).with('mytable').and_return('mytable')
 
@@ -10,31 +11,31 @@ module YamlDb
         @io = StringIO.new
       end
 
-      it "truncates the table" do
-        allow(ActiveRecord::Base.connection).to receive(:execute).with("TRUNCATE mytable").and_return(true)
-        expect(ActiveRecord::Base.connection).not_to receive(:execute).with("DELETE FROM mytable")
+      it 'truncates the table' do
+        allow(ActiveRecord::Base.connection).to receive(:execute).with('TRUNCATE mytable').and_return(true)
+        expect(ActiveRecord::Base.connection).not_to receive(:execute).with('DELETE FROM mytable')
         Load.truncate_table('mytable')
       end
 
-      it "deletes the table if truncate throws an exception" do
-        expect(ActiveRecord::Base.connection).to receive(:execute).with("TRUNCATE mytable").and_raise()
-        expect(ActiveRecord::Base.connection).to receive(:execute).with("DELETE FROM mytable").and_return(true)
+      it 'deletes the table if truncate throws an exception' do
+        expect(ActiveRecord::Base.connection).to receive(:execute).with('TRUNCATE mytable').and_raise
+        expect(ActiveRecord::Base.connection).to receive(:execute).with('DELETE FROM mytable').and_return(true)
         Load.truncate_table('mytable')
       end
 
-      it "calls reset pk sequence if the connection adapter is postgres" do
+      it 'calls reset pk sequence if the connection adapter is postgres' do
         expect(ActiveRecord::Base.connection).to receive(:respond_to?).with(:reset_pk_sequence!).and_return(true)
         expect(ActiveRecord::Base.connection).to receive(:reset_pk_sequence!).with('mytable')
         Load.reset_pk_sequence!('mytable')
       end
 
-      it "does not call reset pk sequence for other adapters" do
+      it 'does not call reset pk sequence for other adapters' do
         expect(ActiveRecord::Base.connection).to receive(:respond_to?).with(:reset_pk_sequence!).and_return(false)
         expect(ActiveRecord::Base.connection).not_to receive(:reset_pk_sequence!)
         Load.reset_pk_sequence!('mytable')
       end
 
-      it "inserts records into a table" do
+      it 'inserts records into a table' do
         allow(ActiveRecord::Base.connection).to receive(:quote_column_name).with('a').and_return('a')
         allow(ActiveRecord::Base.connection).to receive(:quote_column_name).with('b').and_return('b')
         allow(ActiveRecord::Base.connection).to receive(:quote).with(1).and_return("'1'")
@@ -44,10 +45,10 @@ module YamlDb
         expect(ActiveRecord::Base.connection).to receive(:execute).with("INSERT INTO mytable (a,b) VALUES ('1','2')")
         expect(ActiveRecord::Base.connection).to receive(:execute).with("INSERT INTO mytable (a,b) VALUES ('3','4')")
 
-        Load.load_records('mytable', ['a', 'b'], [[1, 2], [3, 4]])
+        Load.load_records('mytable', %w[a b], [[1, 2], [3, 4]])
       end
 
-      it "quotes column names that correspond to sql keywords" do
+      it 'quotes column names that correspond to sql keywords' do
         allow(ActiveRecord::Base.connection).to receive(:quote_column_name).with('a').and_return('a')
         allow(ActiveRecord::Base.connection).to receive(:quote_column_name).with('count').and_return('"count"')
         allow(ActiveRecord::Base.connection).to receive(:quote).with(1).and_return("'1'")
@@ -57,17 +58,16 @@ module YamlDb
         expect(ActiveRecord::Base.connection).to receive(:execute).with("INSERT INTO mytable (a,\"count\") VALUES ('1','2')")
         expect(ActiveRecord::Base.connection).to receive(:execute).with("INSERT INTO mytable (a,\"count\") VALUES ('3','4')")
 
-        Load.load_records('mytable', ['a', 'count'], [[1, 2], [3, 4]])
+        Load.load_records('mytable', %w[a count], [[1, 2], [3, 4]])
       end
 
-      it "truncates the table and then loads the records into the table" do
+      it 'truncates the table and then loads the records into the table' do
         expect(Load).to receive(:truncate_table).with('mytable')
-        expect(Load).to receive(:load_records).with('mytable', ['a', 'b'], [[1, 2], [3, 4]])
+        expect(Load).to receive(:load_records).with('mytable', %w[a b], [[1, 2], [3, 4]])
         expect(Load).to receive(:reset_pk_sequence!).with('mytable')
 
-        Load.load_table('mytable', { 'columns' => [ 'a', 'b' ], 'records' => [[1, 2], [3, 4]] })
+        Load.load_table('mytable', 'columns' => %w[a b], 'records' => [[1, 2], [3, 4]])
       end
-
     end
   end
 end

--- a/spec/yaml_db/serialization_helper_utils_spec.rb
+++ b/spec/yaml_db/serialization_helper_utils_spec.rb
@@ -1,56 +1,57 @@
+# frozen_string_literal: true
+
 module YamlDb
   module SerializationHelper
     RSpec.describe Utils do
-
       before do
         allow(ActiveRecord::Base).to receive(:connection).and_return(double('connection').as_null_object)
       end
 
-      it "returns an array of hash values using an array of ordered keys" do
-        expect(Utils.unhash({ 'a' => 1, 'b' => 2 }, [ 'b', 'a' ])).to eq([ 2, 1 ])
+      it 'returns an array of hash values using an array of ordered keys' do
+        expect(Utils.unhash({ 'a' => 1, 'b' => 2 }, %w[b a])).to eq([2, 1])
       end
 
-      it "unhashes each hash to an array using an array of ordered keys" do
-        expect(Utils.unhash_records([ { 'a' => 1, 'b' => 2 }, { 'a' => 3, 'b' => 4 } ], [ 'b', 'a' ])).to eq([ [ 2, 1 ], [ 4, 3 ] ])
+      it 'unhashes each hash to an array using an array of ordered keys' do
+        expect(Utils.unhash_records([{ 'a' => 1, 'b' => 2 }, { 'a' => 3, 'b' => 4 }], %w[b a])).to eq([[2, 1], [4, 3]])
       end
 
-      it "returns true if it is a boolean type" do
-        expect(Utils.is_boolean(true)).to be true
-        expect(Utils.is_boolean('true')).to be false
+      it 'returns true if it is a boolean type' do
+        expect(Utils.boolean?(true)).to be true
+        expect(Utils.boolean?('true')).to be false
       end
 
-      it "returns an array of boolean columns" do
-        allow(ActiveRecord::Base.connection).to receive(:columns).with('mytable').and_return([ double('a',:name => 'a',:type => :string), double('b', :name => 'b',:type => :boolean) ])
+      it 'returns an array of boolean columns' do
+        allow(ActiveRecord::Base.connection).to receive(:columns).with('mytable').and_return([double('a', name: 'a', type: :string), double('b', name: 'b', type: :boolean)])
         expect(Utils.boolean_columns('mytable')).to eq(['b'])
       end
 
-      it "quotes the table name" do
+      it 'quotes the table name' do
         expect(ActiveRecord::Base.connection).to receive(:quote_table_name).with('values').and_return('`values`')
         expect(Utils.quote_table('values')).to eq('`values`')
       end
 
-      it "converts ruby booleans to true and false" do
+      it 'converts ruby booleans to true and false' do
         expect(Utils.convert_boolean(true)).to be true
         expect(Utils.convert_boolean(false)).to be false
       end
 
-      it "converts ruby strings t and f to true and false" do
+      it 'converts ruby strings t and f to true and false' do
         expect(Utils.convert_boolean('t')).to be true
         expect(Utils.convert_boolean('f')).to be false
       end
 
-      it "converts ruby strings 1 and 0 to true and false" do
+      it 'converts ruby strings 1 and 0 to true and false' do
         expect(Utils.convert_boolean('1')).to be true
         expect(Utils.convert_boolean('0')).to be false
       end
 
-      it "converts ruby integers 1 and 0 to true and false" do
+      it 'converts ruby integers 1 and 0 to true and false' do
         expect(Utils.convert_boolean(1)).to be true
         expect(Utils.convert_boolean(0)).to be false
       end
 
-      describe ".quote_column" do
-        it "quotes the column name" do
+      describe '.quote_column' do
+        it 'quotes the column name' do
           allow(ActiveRecord::Base.connection).to receive(:quote_column_name).with('id').and_return('`id`')
           expect(Utils.quote_column('id')).to eq('`id`')
         end

--- a/spec/yaml_db/utils_spec.rb
+++ b/spec/yaml_db/utils_spec.rb
@@ -1,23 +1,23 @@
+# frozen_string_literal: true
+
 module YamlDb
   RSpec.describe Utils do
-
-    it "turns an array with one record into a yaml chunk" do
-      expect(Utils.chunk_records([ %w(a b) ])).to eq(<<EOYAML
+    it 'turns an array with one record into a yaml chunk' do
+      expect(Utils.chunk_records([%w[a b]])).to eq(<<EOYAML
   - - a
     - b
 EOYAML
-      )
+                                                  )
     end
 
-    it "turns an array with two records into a yaml chunk" do
-      expect(Utils.chunk_records([ %w(a b), %w(x y) ])).to eq(<<EOYAML
+    it 'turns an array with two records into a yaml chunk' do
+      expect(Utils.chunk_records([%w[a b], %w[x y]])).to eq(<<EOYAML
   - - a
     - b
   - - x
     - y
 EOYAML
-      )
+                                                           )
     end
-
   end
 end

--- a/yaml_db.gemspec
+++ b/yaml_db.gemspec
@@ -1,28 +1,39 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'yaml_db/version'
 
 Gem::Specification.new do |s|
-  s.platform      = Gem::Platform::RUBY
-  s.name          = "yaml_db"
-  s.version       = YamlDb::VERSION
-  s.authors       = ["Adam Wiggins", "Orion Henry"]
-  s.summary       = %q{yaml_db allows export/import of database into/from yaml files}
-  s.description   = "\nYamlDb is a database-independent format for dumping and restoring data.  It complements the database-independent schema format found in db/schema.rb.  The data is saved into db/data.yml.\nThis can be used as a replacement for mysqldump or pg_dump, but only for the databases typically used by Rails apps.  Users, permissions, schemas, triggers, and other advanced database features are not supported - by design.\nAny database that has an ActiveRecord adapter should work.\n"
-  s.homepage      = "https://github.com/yamldb/yaml_db"
-  s.license       = "MIT"
+  s.add_development_dependency 'bundler', '~> 1.14'
+  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'sqlite3', '~> 1.3'
 
-  s.extra_rdoc_files = ["README.md"]
-  s.files = Dir['README.md', 'lib/**/*']
-  s.require_paths = ["lib"]
+  s.add_runtime_dependency 'rails', '>= 3.0'
+  s.add_runtime_dependency 'rake', '>= 0.8.7'
 
-  s.required_ruby_version = ">= 1.8.7"
+  s.authors = ['Adam Wiggins', 'Orion Henry']
 
-  s.add_runtime_dependency "rails", ">= 3.0"
-  s.add_runtime_dependency "rake", ">= 0.8.7"
+  s.description = <<~YAMLDB
+    YamlDb is a database-independent format for dumping and restoring data. It complements
+    the database-independent schema format found in db/schema.rb. The data is saved into db/data.yml.
 
-  s.add_development_dependency "bundler", "~> 1.14"
-  s.add_development_dependency "rspec", "~> 3.0"
-  s.add_development_dependency "sqlite3", "~> 1.3"
+    This can be used as a replacement for mysqldump or pg_dump, but only for the databases typically
+    used by Rails apps. Users, permissions, schemas, triggers, and other advanced
+    database features are not supported - by design.
+
+    Any database that has an ActiveRecord adapter should work.
+  YAMLDB
+
+  s.extra_rdoc_files = ['README.md']
+  s.files            = Dir['README.md', 'lib/**/*']
+  s.homepage         = 'https://github.com/yamldb/yaml_db'
+  s.license          = 'MIT'
+  s.name             = 'yaml_db'
+  s.platform         = Gem::Platform::RUBY
+  s.require_paths    = ['lib']
+  s.required_ruby_version = '>= 2.5'
+  s.summary          = 'yaml_db allows export/import of database into/from yaml files'
+  s.version          = YamlDb::VERSION
 end


### PR DESCRIPTION

I have added a whitelist and blacklist to control what tables are dumped. 

If the whitelist is provided, it is used as the list of tables to dump, rather than all. 

Any tables mentioned in the blacklist are always excluded. 

You can provide a blacklist and whitelist at the same time. 
